### PR TITLE
Group senior statements into sections

### DIFF
--- a/career-path/senior.md
+++ b/career-path/senior.md
@@ -1,77 +1,81 @@
-
 ## Senior
 
+Senior level means you should be:
 
-Proficient in a wide range of technical systems, involved in selecting technology, approaches, and designing systems. Leading teams to make the appropriate tradeoffs to ensure delivery, and helps others to deliver. Widely visible internally and externally talking about work and technical issues, people seek them out for help and advice. Helping to develop others, improving the structure of the department and performing long term planning. A role model for technical culture and constructive communication.
-Evaluating different means of technical tooling, e.g. documents store versus relational databases or choosing Make or Grunt for front-end builds
+- Proficient in a wide range of technical systems, involved in selecting technology, approaches, and designing systems.
 
+- Leading teams to make the appropriate tradeoffs to ensure delivery, and helps others to deliver.
 
-Leading on the production of complex stories which meet user needs to the necessary standards
+- Widely visible internally and externally talking about work and technical issues, people seek them out for help and advice.
 
-Acting as a technical lead or line manager
+- Helping to develop others, improving the structure of the department and performing long term planning.
 
-Ensuring the team’s work is aligned with wider product direction and the work of other teams
+- A role model for technical culture and constructive communication.
 
-Manage stakeholders/non-technical staff and expectations around what is possible for delivery
+- Evaluating different means of technical tooling, e.g. documents store versus relational databases or choosing Make or Grunt for front-end builds
 
-Taking the lead in an incident, pulling in the skills to build an incident team, and coordinating the response
+- Leading on the production of complex stories which meet user needs to the necessary standards
 
-Designing systems and setting technical direction for a project or area
+- Acting as a technical lead or line manager
 
-Being involved in the wider developer community, blogging or speaking at conferences
+- Ensuring the team’s work is aligned with wider product direction and the work of other teams
 
-Helping the wider Civil Service and other digital teams across government
+- Manage stakeholders/non-technical staff and expectations around what is possible for delivery
 
-Assessing services for operational readiness
+- Taking the lead in an incident, pulling in the skills to build an incident team, and coordinating the response
 
-Estimating work, understanding relative complexity of different tasks (for the team's work)
+- Designing systems and setting technical direction for a project or area
 
-Demonstrates strong skills and ability to mentor others in:
+- Being involved in the wider developer community, blogging or speaking at conferences
 
-The language and tools used by the team
+- Helping the wider Civil Service and other digital teams across government
 
+- Assessing services for operational readiness
 
-Approaching debugging in a methodical manner
+- Estimating work, understanding relative complexity of different tasks (for the team's work)
 
-Choosing between using core language features, their own code and third-party libraries, with appropriate validation
+### Skills
 
+A senior developer should demonstrate strong skills and ability to mentor others in:
 
-Solving problems using technology providing the simplest solutions for complex problems, understanding where software is the answer
+- The language and tools used by the team
 
-Managing technical debt appropriately and proportionately
+- Approaching debugging in a methodical manner
 
-Taking responsibility for code quality and testing, requires minimal direction and oversight
+- Choosing between using core language features, their own code and third-party libraries, with appropriate validation
 
-Having deep understanding of how to mitigate common security threats
+- Solving problems using technology providing the simplest solutions for complex problems, understanding where software is the answer
 
-System architecture and how to test system boundaries
+- Managing technical debt appropriately and proportionately
 
-Keeping up to date with industry trends in a particular technology area
+- Taking responsibility for code quality and testing, requires minimal direction and oversight
 
-Collaborating well in multidisciplinary teams
+- Having deep understanding of how to mitigate common security threats
 
-Identifying and communicating emerging risks to project delivery
+- System architecture and how to test system boundaries
 
-Participating in the agile process and representing technical concerns
+- Keeping up to date with industry trends in a particular technology area
 
-Considering resilience, performance, and failure modes when designing systems, and understands how to validate those concerns
+- Collaborating well in multidisciplinary teams
 
-End to end responsibility on projects of increasing complexity, contributes to common code.
+- Identifying and communicating emerging risks to project delivery
 
-Balancing need for precision against deadlines
+- Participating in the agile process and representing technical concerns
 
-Go to 'expert' in one area of the codebase
+- Considering resilience, performance, and failure modes when designing systems, and understands how to validate those concerns
 
-Helping colleagues with their career development, finding ways to improve
-the capabilities of developer colleagues, e.g. tech talks, mentoring
+- End to end responsibility on projects of increasing complexity, contributes to common code.
 
-Persistent in the face of roadblocks; dispatches them efficiently, pulling in others as necessary.
+- Balancing need for precision against deadlines
+
+- Go to 'expert' in one area of the codebase
+
+- Helping colleagues with their career development, finding ways to improve the capabilities of developer colleagues, e.g. tech talks, mentoring
+
+- Persistent in the face of roadblocks; dispatches them efficiently, pulling in others as necessary.
 
 ## Role Specific
 
+- Developer: Understanding of core web technologies, eg HTTP, databases, web applications
 
-Developer: Understanding of core web technologies, eg HTTP, databases, web applications
-
-
-Web operations: Understanding of core systems technologies, eg TCP/IP networking, operating system fundamentals, capacity planning, monitoring
-
+- Web operations: Understanding of core systems technologies, eg TCP/IP networking, operating system fundamentals, capacity planning, monitoring


### PR DESCRIPTION
I've used the same structure as for mid-level, in an attempt to
distinguish between responsibilities/behaviours and skills/knowledge.

This adds back some of the structure that was present in the original
document, but this is just a first step. I think this section could
still do with a lot of editing.

This role has more statements than any other in the technologist's
career path and I think we could better emphasise what the core
responsibilities and skills actually are.

Part of the problem is there are a lot of responsibilities mixed in that
don't apply to every senior; for example:
- acting as a technical lead or line manager
- go to expert on one area of the codebase
- statements relating to civil service corporate objectives, which can
  be met in any number of ways ("visible externally", "helping the
  wider civil service", "wider developer community, blogging or speaking
  at conferences", "helping colleagues with career development"). I think
  we could cover these things (they are duplicated elsewhere) but they
  don't feel very role-specific.

Also, in the original document, the first few statements are more of a
summary, and there is some duplication between these and statements
further down so there we could perhaps combine some of the competencies.
