### PR TITLE
Link to GDS tech manual and styleguides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,3 +12,9 @@ contribute a guide or a competency statement:
 
 If you're not sure about anything, email us at gds-tech-learning-path-discuss (at) digital.cabinet-office.gov.uk to ask.
 
+### What should go in a guide
+
+* Cover a single topic, and consider splitting guides that are too long.
+* It's ok to be opinionated, but aim to acknowledge multiple approaches where possible.
+* Introduce the topic, mentioning any assumed knowledge at the start.
+* Don't use a guide to document technical decisions or conventions we follow within GDS. Instead link to something canonical like the [GDS Technical Guidance](https://gds-tech-docs.cloudapps.digital/#gds-technical-guidance).

--- a/guides/programming-languages.md
+++ b/guides/programming-languages.md
@@ -1,13 +1,13 @@
 
 # Programming languages
 
-## General purpose languages
+## Core languages
+Although these aren't the only languages we use, [these are the ones we prefer for core web development tasks](https://gds-tech-docs.cloudapps.digital/standards/programming-languages.html#programming-languages).
 
-[Ruby](languages/ruby.md)
+- [Ruby](languages/ruby.md)
+- [Python](languages/python.md)
+- [Java](languages/java.md)
 
-[Python](languages/python.md)
-
-[Java](languages/java.md)
 
 ## Infrastructure as code
 

--- a/guides/version-control.md
+++ b/guides/version-control.md
@@ -4,6 +4,12 @@ Version control facilitates collaboration amongst a team working on a shared cod
 
 Version control also allows for controlled testing and deployment of known software versions, which is an essential part of any reliable quality control process. Nowadays this will typically be in the form of a continuous integration/continuous deployment pipeline.
 
+## Coding in the open at GDS
+
+At GDS we use Github to store our git repositories and review work in progress.
+Most of our source code is open to the public.
+
+[The GDS technical guidance manual documents how we manage our source code repositories.](https://gds-tech-docs.cloudapps.digital/standards/source-code.html#source-code)
 
 ## What you should be able to do
 
@@ -21,7 +27,7 @@ Version control also allows for controlled testing and deployment of known softw
 - Open a pull request
 - Understand what rebasing is
 - Understand when it is necessary to force push (and when NOT to :-))
-- Understand the git styleguide
+- Understand the [git styleguide](https://github.com/alphagov/styleguides/blob/master/git.md)
 
 We’d expect a Junior developer to be able to do all of these things.
 
@@ -34,9 +40,6 @@ We’d expect a Junior developer to be able to do all of these things.
 - Understand git hooks and when to use them
 
 ## Resources
-- Guide to git - basic commands and concepts like 
+- Guide to git - basic commands and concepts like
 - Why we do code reviews; why pull requests
-- Git styleguide (https://github.com/alphagov/styleguides/blob/master/git.md)
-
-
-
+- [Our Git styleguide](https://github.com/alphagov/styleguides/blob/master/git.md)


### PR DESCRIPTION
We now have https://github.com/alphagov/gds-tech which documents how we
do stuff at GDS, including particular technologies and software we've
chosen to use.

I think some of this gives specific examples of things we talk about in
relation to competencies, and we can tie it all together.

I've added a section to the contributing guide about what should go in a
guide here and when we should link out to other resources.

There's room to expand this, but hopefully this is a good starting
point.

https://github.com/alphagov/gds-tech-learning-pathway/issues/18