### PR TITLE
Add initial content to owning development plan

### DIFF
--- a/career-path/competencies/owning-their-development-plan.md
+++ b/career-path/competencies/owning-their-development-plan.md
@@ -1,2 +1,41 @@
+# Owning their development plan
 
-## Owning their development plan
+Developers should take responsibility for their continued learning and
+development by forming a development plan.
+
+## Your role as a developer
+
+Developers should identify areas they are interested in and areas where they
+have skill gaps and seek out suitable resources to help further their
+understanding. This can be in the form of books, courses, self-study,
+conferences, mentoring etc.
+
+Your development plan should be reflected in your objective (for example under
+the heading "What are you doing for personal development?") and discussed with
+your line manager.
+
+### Junior level
+
+You will probably have broad goals in your development plan as you become familiar
+with the large surface area of modern development and web/dev ops.
+
+As a junior you have 20% time to work on a project that is non-delivery related
+but benefits GDS. A 20% project should have some specific learning outcomes and
+pairing with other juniors is encouraged to help juniors support and learn from
+each other.
+
+There is a spreadsheet of suggested 20% time projects
+(https://docs.google.com/spreadsheets/d/115ZyXsAljiZxO_UmI2ruT81i3TsU_gIxeesv62qNJAQ/edit#gid=887531206).
+
+You should discuss the project with your line manager before starting on it.
+
+### Mid level
+
+Your development plan may begin to focus more on higher level concepts - how to
+design maintainable and scalable solutions. Learning not only the intricacies of
+code, but also other skills that go into developing software like user research
+and writing good user stories. A mid level plan might also include some
+mentoring and presenting to help spread knowledge through the organisation.
+
+Specific technology learning might be project based, for example if you are
+working on search you might delve into Elasticsearch.

--- a/career-path/competencies/owning-their-development-plan.md
+++ b/career-path/competencies/owning-their-development-plan.md
@@ -25,7 +25,7 @@ pairing with other juniors is encouraged to help juniors support and learn from
 each other.
 
 There is a spreadsheet of suggested 20% time projects
-(https://docs.google.com/spreadsheets/d/115ZyXsAljiZxO_UmI2ruT81i3TsU_gIxeesv62qNJAQ/edit#gid=887531206).
+(https://docs.google.com/spreadsheets/d/1Nrt4oZEMYZR_54SdKApzNrBDKgxafIiPpQSfb3taUDE/edit#gid=492186728).
 
 You should discuss the project with your line manager before starting on it.
 


### PR DESCRIPTION
Some basic ideas here.

I'm not really sure if this fits in to our template - i.e. if we expect the development plan to look substantially different for different levels or if this is really just about what each person wishes to pursue based on interest and own career goals. It somewhat ties in to what we expect people to know at various levels I suppose, so perhaps that should be reflected in this?