### PR TITLE
Add a licence

### DIFF
--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,0 +1,3 @@
+# Licence
+
+The content of this repository is covered by the [Open Government Licence](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).

--- a/README.md
+++ b/README.md
@@ -60,3 +60,7 @@ However, this repo should not contain any personal names or information because 
 ## Licence
 
 [Open Government Licence](LICENCE.md).
+
+## Code of conduct
+
+This project is developed under the [Alphagov Code of Conduct](https://github.com/alphagov/code-of-conduct)

--- a/README.md
+++ b/README.md
@@ -56,3 +56,7 @@ We want to encourage learning collaboratively in the GDS technology community, a
 - people to share what they're wanting to learn so that they can join up with others wanting to learn the same things, or get support from others
 
 However, this repo should not contain any personal names or information because we intend to make this repo public.
+
+## Licence
+
+[Open Government Licence](LICENCE.md).


### PR DESCRIPTION
I think we should use the Open Government Licence for consistency with other projects that are just text - like the GDS Way.

Resolves https://github.com/alphagov/gds-tech-learning-pathway/issues/21