### PR TITLE
Puppet

### DIFF
--- a/resources/languages/puppet.md
+++ b/resources/languages/puppet.md
@@ -10,16 +10,13 @@ those computers and makes configuration changes.
 #### Which version?
 
 The language does vary between versions. Most, but not all, of the basic
-language from older versions, such as 2.x and 3.x, will work on newer versions. 
+language from older versions, such as 2.x and 3.x, will work on newer versions.
 
 As a rule, start with the latest version, unless the team in which you work or
 a tutorial you are following uses an older version.
 
 #### Learning materials
-
-# TODO: follow this tutorial with 4.x and make sure it still works
-- [A tutorial](https://web.archive.org/web/20170507015216/http://www.pindi.us:80/blog/getting-started-puppet) that explains
-  why you might want to use puppet and guides you through a getting started
-  task. Old, but covers basics that haven't changed in newer versions.
-- The [puppet cookbook](https://www.puppetcookbook.com/) has good examples of
-  how to do specific things using puppet.
+- [Introduction to Puppet](https://davidwinter.me/introduction-to-puppet/)
+- [Overview of Puppet's architecture](https://puppet.com/docs/puppet/5.5/architecture.html)
+- For a more thorough introduction to the Puppet ecosystem see [Puppet's learning roadmaps](https://learn.puppet.com/learning-roadmaps)
+- The [puppet cookbook](https://www.puppetcookbook.com/) has good examples of how to do specific things using puppet.

--- a/resources/languages/puppet.md
+++ b/resources/languages/puppet.md
@@ -20,3 +20,4 @@ a tutorial you are following uses an older version.
 - [Overview of Puppet's architecture](https://puppet.com/docs/puppet/5.5/architecture.html)
 - For a more thorough introduction to the Puppet ecosystem see [Puppet's learning roadmaps](https://learn.puppet.com/learning-roadmaps)
 - The [puppet cookbook](https://www.puppetcookbook.com/) has good examples of how to do specific things using puppet.
+- The GDS Library has [multiple](https://gds-library.cloudapps.digital/books/98) [books](https://gds-library.cloudapps.digital/books/4) on [puppet](https://gds-library.cloudapps.digital/books/94).


### PR DESCRIPTION
I've removed a now archived link as it's for an old version anyway. I've combined links from an old wiki page on puppet
https://sites.google.com/a/digital.cabinet-office.gov.uk/gds-technology/learning-and-development/learning-resources/learning-puppet