### PR TITLE
Add a template for resource lists

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,8 @@ Here are a few ways you can help:
 
 1. [Review open pull requests](https://github.com/alphagov/gds-tech-learning-pathway/pulls). You don't have to be an expert on the topic to make suggestions.
 2. Improve the copy so it's [easier to understand](https://www.gov.uk/guidance/content-design/writing-for-gov-uk).
-3. Write a resource list for a topic you're interested in
-4. Write a competency statement following the [template](https://github.com/alphagov/gds-tech-learning-pathway/blob/master/career-path/competencies/TEMPLATE.md). Speak to someone before starting this as we have a list of competencies and what we think should go in them.
+3. Write a competency statement following the [template](https://github.com/alphagov/gds-tech-learning-pathway/blob/master/career-path/competencies/TEMPLATE.md). Speak to someone before starting this as we have a list of competencies and what we think should go in them.
+4. Write a resource list for a topic you're interested in, following the [template](resources/TEMPLATE.md)
 4. Triage [issues](https://github.com/alphagov/gds-tech-learning-pathway/issues) and work out how they can be incorporated into the existing structure. This might be just adding a link to a resource list.
 5. Raise an issue for something that is currently missing from the learning pathway.
 

--- a/career-path/competencies/TEMPLATE.md
+++ b/career-path/competencies/TEMPLATE.md
@@ -20,10 +20,12 @@ How does it relate to your role and responsibilities?
 
 [What it looks like at senior level.]
 
-### Related guides [optional]
+### Resources [optional]
+Here you can link to:
 
-[Links to guides on topics related to this competency]
+- Resource list pages
+- The GDS way
+- The service manual
+- Anything officially maintained by GDS
 
-### External Resources [optional]
-
-[Links to external resources]
+Avoid linking directly to external resources, as we think this will make it harder to review and update the career path section. Consider extracting them into a separate resource list and linking to that instead.

--- a/resources/TEMPLATE.md
+++ b/resources/TEMPLATE.md
@@ -1,0 +1,19 @@
+## [Compiling a resource list]
+
+[A short summary of the topic]
+
+### Starting out
+
+In this section, write for someone who knows nothing about the topic. If talking about technology, give a simple runnable example. This section should introduce subtopics and terminology rather than going into depth. 
+
+### [Other sections]
+
+[Examples: important concepts, best practices, related technologies]
+
+### Reference documentation
+
+[Official reference guides]
+
+### Learning materials
+
+This can contain any kind of resource including blog posts, videos, books and tools. Draw attention to free materials, books in the GDS library, and internal training we run at GDS.


### PR DESCRIPTION
Add a template for resource lists so we've got examples of both kinds of page.

We previously discussed this structure and raised
https://github.com/alphagov/gds-tech-learning-pathway/issues/44 about what should go in a competency page vs a resource list. This just documents that. I've intentionally left the resource list template quite basic because the one's we've written vary a lot in structure, but I think that's fine.