### PR TITLE
Add details about the GDS Java community and meetings

### DIFF
--- a/source/resources/languages/java.html.md.erb
+++ b/source/resources/languages/java.html.md.erb
@@ -56,3 +56,11 @@ Common build tools are [Gradle](http://gradle.org/) and [Maven](http://books.son
 - [Effective Java](https://gds-library.cloudapps.digital/books/573) - available in the GDS Library
 - [Java for complete beginners](https://courses.caveofprogramming.com/p/java-for-complete-beginners) - a free online course that assumes no prior knowledge
 - [Better Java](https://github.com/cxxr/better-java) - advice on code style and common libraries/tools
+
+### Java community at GDS
+There is an informal Java community at GDS.
+
+- Slack channel: #java
+- Mailing list: [GDS Tech Java Community Members](https://groups.google.com/a/digital.cabinet-office.gov.uk/forum/#!forum/gds-tech-java-community-members)
+
+Java community meetings are held once a month, featuring presentations, demos and discussions. Join the mailing list to get an invitation. Suggest agenda topics in the Slack channel. Notes from previous meetings can be found in the mailing list archives.


### PR DESCRIPTION
@MatMoore suggested having details of the Java community meetings on the Java page would be good