### PR TITLE
Add review dates to all competency and resource page

### DIFF
--- a/source/career-path/leading-and-communicating/awareness-of-wider-community.html.md
+++ b/source/career-path/leading-and-communicating/awareness-of-wider-community.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 50
+last_reviewed_on: 2018-11-16
+review_in: 1 year
+title: Showing awareness of the wider tech community
 ---
 
 # Showing awareness of the wider tech community

--- a/source/career-path/leading-and-communicating/leading-on-stories.html.md
+++ b/source/career-path/leading-and-communicating/leading-on-stories.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 10
+last_reviewed_on: 2018-11-16
+review_in: 1 month
+title: Leading on delivering stories
 ---
 
 # Leading on delivering stories

--- a/source/career-path/leading-and-communicating/pair-programming.html.md
+++ b/source/career-path/leading-and-communicating/pair-programming.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 60
+last_reviewed_on: 2018-11-16
+review_in: 1 month
+title: Pair programming
 ---
 
 # Pair programming

--- a/source/career-path/leading-and-communicating/sharing-knowledge-with-others.html.md
+++ b/source/career-path/leading-and-communicating/sharing-knowledge-with-others.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 40
+last_reviewed_on: 2018-11-16
+review_in: 1 month
+title: Sharing knowledge with others
 ---
 
 # Sharing knowledge with others

--- a/source/career-path/leading-and-communicating/wider-context-of-work.html.md
+++ b/source/career-path/leading-and-communicating/wider-context-of-work.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 20
+last_reviewed_on: 2018-11-16
+review_in: 1 month
+title: Being aware and guided by the wider context of your work
 ---
 
 # Being aware and guided by the wider context of your work

--- a/source/career-path/leading-and-communicating/writing-and-speaking.html.md
+++ b/source/career-path/leading-and-communicating/writing-and-speaking.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 30
+last_reviewed_on: 2018-11-16
+review_in: 1 month
+title: Writing and speaking about your work externally
 ---
 
 # Writing and speaking about your work externally

--- a/source/career-path/technical-skills/assessing-performance.html.md
+++ b/source/career-path/technical-skills/assessing-performance.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 90
+last_reviewed_on: 2018-11-16
+review_in: 1 year
+title: Assessing performance
 ---
 
 # Assessing performance

--- a/source/career-path/technical-skills/building-secure-services.html.md
+++ b/source/career-path/technical-skills/building-secure-services.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 80
+last_reviewed_on: 2018-11-16
+review_in: 1 year
+title: Building secure services
 ---
 
 # Building secure services

--- a/source/career-path/technical-skills/designing-and-testing-for-accessibility.html.md
+++ b/source/career-path/technical-skills/designing-and-testing-for-accessibility.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 70
+last_reviewed_on: 2018-11-16
+review_in: 1 month
+title: Designing and testing for accessibility
 ---
 
 # Designing and testing for accessibility

--- a/source/career-path/technical-skills/designing-for-reliability.html.md
+++ b/source/career-path/technical-skills/designing-for-reliability.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 100
+last_reviewed_on: 2018-11-16
+review_in: 1 month
+title: Designing for reliability
 ---
 
 # Designing for reliability

--- a/source/career-path/technical-skills/designing-technical-features.html.md
+++ b/source/career-path/technical-skills/designing-technical-features.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 60
+last_reviewed_on: 2018-11-16
+review_in: 1 year
+title: Designing technical features
 ---
 
 # Designing technical features

--- a/source/career-path/technical-skills/diagnosing-and-debugging-issues.html.md
+++ b/source/career-path/technical-skills/diagnosing-and-debugging-issues.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 40
+last_reviewed_on: 2018-11-16
+review_in: 1 year
+title: Diagnosing and debugging issues
 ---
 
 # Diagnosing and debugging issues

--- a/source/career-path/technical-skills/selecting-technology.html.md
+++ b/source/career-path/technical-skills/selecting-technology.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 110
+last_reviewed_on: 2018-11-16
+review_in: 1 month
+title: Selecting technology
 ---
 
 # Selecting technology

--- a/source/career-path/technical-skills/systematic-approach-solving-problems.html.md
+++ b/source/career-path/technical-skills/systematic-approach-solving-problems.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 20
+last_reviewed_on: 2018-11-16
+review_in: 1 year
+title: Using a systematic approach to solving problems
 ---
 
 # Using a systematic approach to solving problems

--- a/source/career-path/technical-skills/technical-debt-tradeoffs.html.md
+++ b/source/career-path/technical-skills/technical-debt-tradeoffs.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 30
+last_reviewed_on: 2018-11-16
+review_in: 1 year
+title: Understanding technical debt
 ---
 
 # Understanding technical debt

--- a/source/career-path/technical-skills/using-appropriate-testing-to-ensure-software-quality.html.md
+++ b/source/career-path/technical-skills/using-appropriate-testing-to-ensure-software-quality.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 50
+last_reviewed_on: 2018-11-16
+review_in: 1 year
+title: Using appropriate testing to ensure software quality
 ---
 
 # Using appropriate testing to ensure software quality

--- a/source/career-path/technical-skills/version-control.html.md
+++ b/source/career-path/technical-skills/version-control.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 10
+last_reviewed_on: 2018-11-16
+review_in: 1 month
+title: Using version control
 ---
 
 # Using version control

--- a/source/career-path/working-practices/building-software-as-a-team.html.md
+++ b/source/career-path/working-practices/building-software-as-a-team.html.md
@@ -1,6 +1,8 @@
 ---
 title: Building software as a team
 weight: 10
+last_reviewed_on: 2018-11-16
+review_in: 1 week
 ---
 
 # Building software as a team

--- a/source/career-path/working-practices/knowing-when-to-ask-for-help.html.md
+++ b/source/career-path/working-practices/knowing-when-to-ask-for-help.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 20
+last_reviewed_on: 2018-11-16
+review_in: 1 week
+title: Knowing when to ask for help
 ---
 # Knowing when to ask for help
 

--- a/source/career-path/working-practices/owning-your-development-plan.html.md
+++ b/source/career-path/working-practices/owning-your-development-plan.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 70
+last_reviewed_on: 2018-11-16
+review_in: 1 month
+title: Owning your development plan
 ---
 
 # Owning your development plan

--- a/source/career-path/working-practices/planning-and-estimating.html.md
+++ b/source/career-path/working-practices/planning-and-estimating.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 30
+last_reviewed_on: 2018-11-16
+review_in: 1 month
+title: Planning and estimating
 ---
 
 # Planning and estimating

--- a/source/career-path/working-practices/prioritising-your-time.html.md
+++ b/source/career-path/working-practices/prioritising-your-time.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 40
+last_reviewed_on: 2018-11-16
+review_in: 1 month
+title: Prioritising your time
 ---
 
 # Prioritising your time

--- a/source/career-path/working-practices/working-as-a-multi-disciplinary-team.html.md
+++ b/source/career-path/working-practices/working-as-a-multi-disciplinary-team.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 60
+last_reviewed_on: 2018-11-16
+review_in: 1 month
+title: Working in a multi disciplinary team
 ---
 
 # Working in a multi disciplinary team

--- a/source/career-path/working-practices/working-independently.html.md
+++ b/source/career-path/working-practices/working-independently.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 50
+last_reviewed_on: 2018-11-16
+review_in: 1 month
+title: Working independently
 ---
 
 # Working independently

--- a/source/resources/datastores/elasticsearch.html.md
+++ b/source/resources/datastores/elasticsearch.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 10
+last_reviewed_on: 2018-11-16
+review_in: 1 month
+title: Elasticsearch
 ---
 
 # Elasticsearch

--- a/source/resources/datastores/sql.html.md
+++ b/source/resources/datastores/sql.html.md
@@ -1,5 +1,7 @@
 ---
 weight: 20
+last_reviewed_on: 2018-11-16
+review_in: 1 year
 ---
 
 # SQL

--- a/source/resources/delivery/designing-apis.html.md
+++ b/source/resources/delivery/designing-apis.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 20
+last_reviewed_on: 2018-11-16
+review_in: 1 year
+title: Designing APIs
 ---
 
 # Designing APIs

--- a/source/resources/delivery/structuring-code.html.md
+++ b/source/resources/delivery/structuring-code.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 30
+last_reviewed_on: 2018-11-16
+review_in: 1 year
+title: Stucturing code
 ---
 
 # Structuring code

--- a/source/resources/delivery/user-story-template.html.md
+++ b/source/resources/delivery/user-story-template.html.md
@@ -1,3 +1,7 @@
+last_reviewed_on: 2018-11-16
+review_in: 1 year
+title: User story template
+
 # User story template
 ```
 #### User need

--- a/source/resources/frameworks/nodejs.html.md
+++ b/source/resources/frameworks/nodejs.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 10
+last_reviewed_on: 2018-11-16
+review_in: 1 year
+title: Node JS
 ---
 
 # Node JS

--- a/source/resources/frameworks/rails.html.md
+++ b/source/resources/frameworks/rails.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 20
+last_reviewed_on: 2018-11-16
+review_in: 1 year
+title: Rails
 ---
 
 # Rails

--- a/source/resources/languages/css.html.md
+++ b/source/resources/languages/css.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 10
+last_reviewed_on: 2018-11-16
+review_in: 1 year
+title: CSS
 ---
 
 # CSS

--- a/source/resources/languages/java.html.md
+++ b/source/resources/languages/java.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 20
+last_reviewed_on: 2018-11-16
+review_in: 1 year
+title: Java
 ---
 # Java
 

--- a/source/resources/languages/javascript.html.md
+++ b/source/resources/languages/javascript.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 30
+last_reviewed_on: 2018-11-16
+review_in: 1 year
+title: Javascript
 ---
 # JavaScript
 

--- a/source/resources/languages/puppet.html.md
+++ b/source/resources/languages/puppet.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 40
+title: Puppet
+last_reviewed_on: 2018-11-16
+review_in: 1 year
 ---
 
 # Puppet

--- a/source/resources/languages/python.html.md
+++ b/source/resources/languages/python.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 50
+title: Python
+last_reviewed_on: 2018-11-16
+review_in: 1 year
 ---
 
 # Python

--- a/source/resources/languages/ruby.html.md
+++ b/source/resources/languages/ruby.html.md
@@ -1,5 +1,8 @@
 ---
 weight: 60
+title: Ruby
+last_reviewed_on: 2018-11-16
+review_in: 1 year
 ---
 
 # Ruby

--- a/source/resources/other/code-reviews.html.md
+++ b/source/resources/other/code-reviews.html.md
@@ -1,3 +1,8 @@
+---
+last_reviewed_on: 2018-11-16
+review_in: 1 year
+title: Code reviews
+---
 # Code reviews
 
 ## What is a code review?
@@ -37,7 +42,7 @@ reviews.
   - Link to the story -
     _Helps the reviewer to get context of the intent of the PR (as well as
     allowing those looking at the trello board to track progress)._
-  - Include screenshots, GIFs or links where necessary - 
+  - Include screenshots, GIFs or links where necessary -
     _This can help to illustrate the end result of the code, highlight changes
     made or explain your design choices._
 

--- a/source/resources/other/documentation.html.md
+++ b/source/resources/other/documentation.html.md
@@ -1,3 +1,8 @@
+---
+last_reviewed_on: 2018-11-16
+review_in: 1 year
+title: Documentation
+---
 # Documentation
 
 ## Resources

--- a/source/resources/other/giving-and-receiving-feedback.html.md
+++ b/source/resources/other/giving-and-receiving-feedback.html.md
@@ -1,3 +1,8 @@
+---
+last_reviewed_on: 2018-11-16
+review_in: 1 year
+title: Giving and receiving feedback
+---
 # Giving and receiving feedback
 
 It's important and helps you grow and learn.

--- a/source/resources/other/handling-incidents.html.md
+++ b/source/resources/other/handling-incidents.html.md
@@ -1,3 +1,8 @@
+---
+last_reviewed_on: 2018-11-16
+review_in: 1 year
+title: Handling incidents
+---
 # Handling incidents
 
 ## Responding to incidents

--- a/source/resources/other/inspiration-and-general-resources.html.md
+++ b/source/resources/other/inspiration-and-general-resources.html.md
@@ -1,3 +1,9 @@
+---
+last_reviewed_on: 2018-11-16
+review_in: 1 year
+title: Inspiration for this project
+---
+
 # Inspiration for this project
 
 This is a list of things that inspired the learning pathway project in GDS.

--- a/source/resources/other/regexp.html.md
+++ b/source/resources/other/regexp.html.md
@@ -1,3 +1,8 @@
+---
+last_reviewed_on: 2018-11-16
+review_in: 1 year
+title: Regular Expressions
+---
 # Regular Expressions
 
 * [Regex Crossword puzzles](https://regexcrossword.com)

--- a/source/resources/other/security.html.md
+++ b/source/resources/other/security.html.md
@@ -1,3 +1,8 @@
+---
+last_reviewed_on: 2018-11-16
+review_in: 1 year
+title: Security
+---
 # Security
 
 Keeping up to date with security risks and best practices are necessary in keeping applications secure.

--- a/source/resources/systems/networking.html.md
+++ b/source/resources/systems/networking.html.md
@@ -1,3 +1,8 @@
+---
+last_reviewed_on: 2018-11-16
+review_in: 1 year
+title: Networking
+---
 # Networking
 
  - [Important Components](#important-components)

--- a/source/resources/systems/reliability-engineering.html.md
+++ b/source/resources/systems/reliability-engineering.html.md
@@ -1,3 +1,8 @@
+---
+last_reviewed_on: 2018-11-16
+review_in: 1 year
+title: Reliability engineering
+---
 # Reliability engineering
 
 ## Additional resources

--- a/source/resources/tools/editors.html.md
+++ b/source/resources/tools/editors.html.md
@@ -1,3 +1,8 @@
+---
+last_reviewed_on: 2018-11-16
+review_in: 1 year
+title: Using editors
+---
 # Using editors
 
 Using editors effectively can greatly increase the speed at which we can try new ideas and approaches.

--- a/source/resources/tools/the-unix-shell.html.md
+++ b/source/resources/tools/the-unix-shell.html.md
@@ -1,3 +1,8 @@
+---
+last_reviewed_on: 2018-11-16
+review_in: 1 year
+title: The unix shell
+---
 # The Unix Shell
 
 The unix shell (you might know it as "the command line", or "the terminal"), is one of the oldest programming environments around that remains in use today. The first shell was designed by [Ken Thompson](https://en.wikipedia.org/wiki/Ken_Thompson) for the Unix operating system, and shells have evolved considerably since: you are more likely to have come across one of either [bash](http://www.gnu.org/software/bash/) or [zsh](http://www.zsh.org/).

--- a/source/ways-of-learning/index.html.md.erb
+++ b/source/ways-of-learning/index.html.md.erb
@@ -1,6 +1,8 @@
 ---
 title: Ways to learn
 weight: 50
+last_reviewed_on: 2018-11-16
+review_in: 1 month
 ---
 
 # Ways to learn


### PR DESCRIPTION
This gives these pages an expiry date which is visible as a banner at the bottom of the page.

The actual review times I've put in are fairly arbitrary, but if we review everythign fairly soon we can choose more appropriate times depending on how happy we are with the content.

See https://github.com/alphagov/tech-docs-gem/pull/12 for more about this feature.

This will enable us to use https://github.com/alphagov/tech-docs-monitor to remind us on slack about stuff that's out of date. I think this is a good way of encouraging contribution and making sure that the content is relevant to the tech community.