### PR TITLE
Add GOV.UK Pay Node.js Pluralsight channel link

### DIFF
--- a/source/resources/frameworks/nodejs.html.md
+++ b/source/resources/frameworks/nodejs.html.md
@@ -8,3 +8,5 @@ weight: 10
 [Comprehensive getting started guide](https://gist.github.com/joepie91/95ed77b71790442b7e61)
 
 [https://nodeschool.io/](https://nodeschool.io/)
+
+[GOV.UK Pay Node.js Pluralsight channel](https://app.pluralsight.com/channels/details/83e0745a-dc2c-45f3-bf7c-2fc5601651e7?s=1)


### PR DESCRIPTION
We are starting a new Pluralsight channel for GOV.UK Pay about useful Node.js resources