### PR TITLE
Add code review links

### DIFF
--- a/source/career-path/leading-and-communicating/leading-on-stories.html.md
+++ b/source/career-path/leading-and-communicating/leading-on-stories.html.md
@@ -41,7 +41,7 @@ This could involve:
 - working with the tech lead and the rest of the team to agree scope and identify risks to delivery early on
 - creating well defined stories for other developers to pick up or suggesting an approach to take
 - helping to resolve blockers
-- making sure code gets code reviewed quickly
+- making sure code gets [code reviewed](/resources/other/code-reviews.html) quickly
 - doing a timeboxed investigation (spike) into a problem area
 
 ## As a tech lead (any level)

--- a/source/career-path/leading-and-communicating/sharing-knowledge-with-others.html.md
+++ b/source/career-path/leading-and-communicating/sharing-knowledge-with-others.html.md
@@ -40,8 +40,7 @@ You can also volunteer for the monthly Technospective to give a longer talk on a
 
 [Working together with other developers](/career-path/competencies/leading-and-communicating/pair-programming.html) is a really good way to share knowledge, since you get to see other dev's workflow, environment and editor/ide config, and general approaches to problem solving.
 
-You should also regularly review other developers' pull requests. It's a good idea to check other work-in-progress before picking up new stories, so that code review doesn't become a bottleneck for the team.
-See [How to review code](https://gds-way.cloudapps.digital/manuals/code-review-guidelines.html) on the GDS way website for guidance about how to do code reviews well.
+You should also regularly review other developers' pull requests. It's a good idea to check other work-in-progress before picking up new stories, so that code review doesn't become a bottleneck for the team. See the [How to review code](https://gds-way.cloudapps.digital/manuals/code-review-guidelines.html) on the GDS way website for guidance about how to do code reviews well.
 
 More suggestions:
 

--- a/source/career-path/leading-and-communicating/sharing-knowledge-with-others.html.md
+++ b/source/career-path/leading-and-communicating/sharing-knowledge-with-others.html.md
@@ -16,7 +16,7 @@ Much of what we’re doing is only possible because of open source code and the 
 ## Your role as developer/webops
 You can share knowledge internally by
 
-- Reviewing other developers' code
+- [Reviewing other developers' code](/resources/other/code-reviews.html)
 - Documenting software you work with
 - Demonstrating work at Show and Tell events and within your team
 - Speaking at a monthly Technospective
@@ -49,7 +49,3 @@ More suggestions:
 - help organise a workshop or presentation
 
 ### Senior level
-
-## Related guides
-
-## External resources

--- a/source/career-path/technical-skills/designing-for-reliability.html.md
+++ b/source/career-path/technical-skills/designing-for-reliability.html.md
@@ -11,7 +11,7 @@ title: Designing for reliability
 
 Writing code is a core part of software development, but our responsibility extends beyond that.
 
-As a developer you are responsible for the whole release process, from code review to
+As a developer you are responsible for the whole release process, from [code review](/resources/other/code-reviews.html) to
 deployment on a production system. You should also ensure that the products you are
 working on are easy to support and operate.
 

--- a/source/career-path/technical-skills/version-control.html.md
+++ b/source/career-path/technical-skills/version-control.html.md
@@ -1,6 +1,6 @@
 ---
 weight: 10
-last_reviewed_on: 2018-11-16
+last_reviewed_on: 2018-12-03
 review_in: 1 month
 title: Using version control
 ---
@@ -57,14 +57,3 @@ We’d expect a Junior developer to be able to do all of these things.
 Writing clear commit messages helps other developers (including your future self) understand why changes were made.
 
 See [styleguide: git](https://github.com/alphagov/styleguides/blob/master/git.md) for some good examples.
-
-## Effective pull requests
-See [styleguide: pull requests](https://github.com/alphagov/styleguides/blob/master/pull-requests.md) for details about how to raise and review pull requests.
-
-We make code review run more smoothly by agreeing on a [common set of coding conventions](https://github.com/alphagov/styleguides), and [using automated tools](https://gdstechnology.blog.gov.uk/2016/09/30/easing-the-process-of-pull-request-reviews/) instead of nitpicking small problems. This lets the reviewer focus on other aspects of the pull request.
-
-### Further reading
-- [The Importance of code reviews](https://www.sitepoint.com/the-importance-of-code-reviews/)
-- [How to conduct effective code reviews](https://blog.digitalocean.com/how-to-conduct-effective-code-reviews/)
-- [Principles of a good code review](https://dev.to/codemouse92/10-principles-of-a-good-code-review-2eg)
-- [The Art of Code Review](https://skillsmatter.com/skillscasts/8085-the-art-of-code-review) (video, 23 minutes)

--- a/source/career-path/technical-skills/version-control.html.md
+++ b/source/career-path/technical-skills/version-control.html.md
@@ -20,10 +20,9 @@ Source code should be [open to the public and published under an open source lic
 
 ## What you should be able to do
 
-- Understand and follow your team’s branching and code review process
+- Understand and follow your team’s branching and [code review](/resources/other/code-reviews.html) process
 - Understand the benefits of having a clear commit history
 - Write clear commit messages for your changes
-- Participate in code review
 
 ## Starting out
 

--- a/source/resources/other/code-reviews.html.md
+++ b/source/resources/other/code-reviews.html.md
@@ -79,6 +79,8 @@ It's usually helpful to include a link to the story in the PR, to provide more c
 
 Some teams automatically deploy PR branches to heroku, so that reviewers can test the branch more easily. This works well for applications that don't need access to protected services or data, for example [GOV.UK frontend](https://github.com/alphagov/govuk-frontend/pull/1075).
 
+To make sure pull requests are reviewed quickly, you can request reviews from specific people through github, or you can use the [Seal bot](https://github.com/binaryberry/seal) to regularly post a list of pull requests that need reviews to your team's slack channel.
+
 ## Further reading
 - [The art of giving and receiving code reviews](http://www.alexandra-hill.com/2018/06/25/the-art-of-giving-and-receiving-code-reviews/)
 - [How to conduct effective code reviews](https://blog.digitalocean.com/how-to-conduct-effective-code-reviews/)

--- a/source/resources/other/code-reviews.html.md
+++ b/source/resources/other/code-reviews.html.md
@@ -80,6 +80,7 @@ If your team is using github, you can set up a [pull request template](https://h
   - Try to respond to every comment.
 
 ## Resources
+- [How to review code](https://gds-way.cloudapps.digital/manuals/code-review-guidelines.html)
 - [The art of giving and receiving code reviews](http://www.alexandra-hill.com/2018/06/25/the-art-of-giving-and-receiving-code-reviews/)
 - [How to conduct effective code reviews](https://blog.digitalocean.com/how-to-conduct-effective-code-reviews/)
 - [Mozilla Science Lab: Reviewing a contribution](https://mozillascience.github.io/codeReview/review.html)

--- a/source/resources/other/code-reviews.html.md
+++ b/source/resources/other/code-reviews.html.md
@@ -42,11 +42,9 @@ reviews.
   - Link to the story -
     _Helps the reviewer to get context of the intent of the PR (as well as
     allowing those looking at the trello board to track progress)._
-  - Include screenshots, GIFs or links where necessary -
+  - Include screenshots, GIFs or links where necessary ([example](https://github.com/alphagov/frontend/pull/784)) -
     _This can help to illustrate the end result of the code, highlight changes
     made or explain your design choices._
-
-If your team is using github, you can set up a [pull request template](https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/) to prompt team members to provide this information whenever they raise a pull request.
 
 ## How to give an effective code review
 
@@ -67,8 +65,7 @@ If your team is using github, you can set up a [pull request template](https://h
     teams labels comments as blocking or non-blocking to give the author a chance
     to only respond to what is absolutely necessary.
 
-
-## How to receive a code review
+## How to receive code review feedback
 
   - Ask questions if you are not sure.
   - Remind yourself that feedback about code is not personal.
@@ -79,10 +76,21 @@ If your team is using github, you can set up a [pull request template](https://h
   - Seek to understand the reviewer's perspective.
   - Try to respond to every comment.
 
-## Resources
+## Tips for improving your team's code reviews
+If you are using github, you can set up a [pull request template](https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/) to prompt team members to provide enough information when they raise a pull request.
+
+You can also make code reviews run more smoothly by adopting [common coding conventions](https://gds-way.cloudapps.digital/manuals/programming-languages.html), and [using automated tools](https://gdstechnology.blog.gov.uk/2016/09/30/easing-the-process-of-pull-request-reviews/) to flag minor problems that don't need to be discussed.
+
+
+## Resources for contributing code
+- [How to raise a good pull request](http://www.annashipman.co.uk/jfdi/good-pull-requests.html)
+- [GOV.UK styleguide: pull requests](https://github.com/alphagov/styleguides/blob/master/pull-requests.md)
+
+## Resources for reviewing code
 - [How to review code](https://gds-way.cloudapps.digital/manuals/code-review-guidelines.html)
 - [The art of giving and receiving code reviews](http://www.alexandra-hill.com/2018/06/25/the-art-of-giving-and-receiving-code-reviews/)
 - [How to conduct effective code reviews](https://blog.digitalocean.com/how-to-conduct-effective-code-reviews/)
+- [The Art of Code Review](https://skillsmatter.com/skillscasts/8085-the-art-of-code-review) (video, 23 minutes)
 - [Mozilla Science Lab: Reviewing a contribution](https://mozillascience.github.io/codeReview/review.html)
 - [Thoughtbot code review guide](https://github.com/thoughtbot/guides/tree/master/code-review)
 - [rOpenSci onboarding guide for reviewers](https://ropensci.github.io/dev_guide/onboarding-guide-for-reviewers.html)

--- a/source/resources/other/code-reviews.html.md
+++ b/source/resources/other/code-reviews.html.md
@@ -1,17 +1,15 @@
 ---
 last_reviewed_on: 2018-12-03
 review_in: 1 month
-title: Code reviews
+title: Conducting effective code reviews
 ---
-# Code reviews
+# Conducting effective code reviews
 
-## What is a code review?
+## What is a code review, and why do it?
 
 A code review is a quality assurance activity in which at least one developer
 (as well as the original author of the code) reviews code in order to spot
 mistakes and improve code quality.
-
-## Why do code reviews?
 
 There are many reasons to carry out code reviews and it has nothing to do with
 the competency of the original author! These include:
@@ -27,43 +25,24 @@ the competency of the original author! These include:
     in areas in which they themselves are not currently working, which may well
     help the team's efficiency and speed up future development._
 
-### Before requesting a code review
+## How to prepare a pull request for code review
 
 Properly prepared pull requests (PRs) lead to quicker and more efficient code
 reviews.
 
-  - Keep the PR as small and easy to review as possible -
-    _Not only does this speed up the code review process but it also increases the
-    likelihood that the reviewer can fully understand the context and intent of
-    the work. Often many small PRs are better than one large one._
-  - Explain any unusual decisions or key points -
-    _This saves the reviewer from needing to ask for clarification on your
-    thought process and often speeds up the review process._
-  - Link to the story -
-    _Helps the reviewer to get context of the intent of the PR (as well as
-    allowing those looking at the trello board to track progress)._
-  - Include screenshots, GIFs or links where necessary ([example](https://github.com/alphagov/frontend/pull/784)) -
-    _This can help to illustrate the end result of the code, highlight changes
-    made or explain your design choices._
+[How to raise a good pull request](http://www.annashipman.co.uk/jfdi/good-pull-requests.html) is a good explanation of how to do this.
 
-## How to give an effective code review
+<!-- Note: the below guidance is very similar to the GOV.UK PR styleguide. If we create a more general guide in the GDS Way, we can just link out to that like we do in the "how to give an effective code review section. -->
 
-  - Be kind and empathetic. Make an effort to ensure that the contributor does
-    not feel like they're being attacked or their competency questioned through
-    your feedback.
-  - Ask good questions; don't make demands. ("What do you think about naming this
-    :user_id?"). Good questions avoid judgment and avoid assumptions about the
-    author's perspective.
-  - Ask for clarification. ("I didn't understand. Can you clarify?")
-  - Be explicit. Remember people don't always understand your intentions via text.
-  - Pull down the code and test it out.
-  - Seek to understand the author's perspective.
-  - Try to identify ways to simplify the code while still solving the problem.
-  - Offer alternative implementations.
-  - Consider how code will work in production.
-  - Communicate which ideas you feel strongly about and which you don't. Some
-    teams labels comments as blocking or non-blocking to give the author a chance
-    to only respond to what is absolutely necessary.
+
+Different teams have different expectations about exactly what goes into a pull request (for example this [pull request styleguide](https://github.com/alphagov/styleguides/blob/master/pull-requests.md) for GOV.UK). But in general, you should:
+
+  - Keep the PR as small as possible. Often many small PRs are easier to review than one large one.
+  - Explain any unusual decisions or key points - this saves the reviewer from needing to ask for clarification on your
+    thought process.
+  - Include screenshots, GIFs or links where necessary ([example](https://github.com/alphagov/frontend/pull/784)).
+    This can help to illustrate the end result of the code, highlight changes
+    made or explain your design choices.
 
 ## How to receive code review feedback
 
@@ -76,18 +55,31 @@ reviews.
   - Seek to understand the reviewer's perspective.
   - Try to respond to every comment.
 
-## Tips for improving your team's code reviews
+## How to give an effective code review
+
+Above all, be kind and empathetic. Make an effort to ensure that the contributor does not feel like they're being attacked or their competency questioned through your feedback. Remember that people don't always understand your intentions via text, so be explicit and seek to understand the author's intent.
+
+For some tips on how to do this well, see:
+
+- [Social aspects of code review](https://mtlynch.io/human-code-reviews-1/)
+- [Phrasing review comments positively](https://codeahoy.com/2016/04/03/effective-code-reviews/)
+
+[How to review code](https://gds-way.cloudapps.digital/manuals/code-review-guidelines.html) in the GDS Way contains more detail about what you should consider when reviewing code at GDS.
+
+## Tips for streamlining code reviews
+Consider running through a checklist before asking for a review or when reviewing somebody else's code. See [checklists for code authors and reviewers](https://engineeringblog.yelp.com/2017/11/code-review-guidelines.html) for some examples.
+
 If you are using github, you can set up a [pull request template](https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/) to prompt team members to provide enough information when they raise a pull request.
 
 You can also make code reviews run more smoothly by adopting [common coding conventions](https://gds-way.cloudapps.digital/manuals/programming-languages.html), and [using automated tools](https://gdstechnology.blog.gov.uk/2016/09/30/easing-the-process-of-pull-request-reviews/) to flag minor problems that don't need to be discussed.
 
+You don't need to have an in depth discussion about every code review comment. Some teams label comments as blocking or non-blocking to give the author a chance to only respond to what is absolutely necessary.
 
-## Resources for contributing code
-- [How to raise a good pull request](http://www.annashipman.co.uk/jfdi/good-pull-requests.html)
-- [GOV.UK styleguide: pull requests](https://github.com/alphagov/styleguides/blob/master/pull-requests.md)
+It's usually helpful to include a link to the story in the PR, to provide more context about why you are making the change. If you use trello, you can use the [github trello poster](https://github.com/emmabeynon/github-trello-poster) tool to automatically update the card with a checklist of all PRs that link to it.
 
-## Resources for reviewing code
-- [How to review code](https://gds-way.cloudapps.digital/manuals/code-review-guidelines.html)
+Some teams automatically deploy PR branches to heroku, so that reviewers can test the branch more easily. This works well for applications that don't need access to protected services or data, for example [GOV.UK frontend](https://github.com/alphagov/govuk-frontend/pull/1075).
+
+## Further reading
 - [The art of giving and receiving code reviews](http://www.alexandra-hill.com/2018/06/25/the-art-of-giving-and-receiving-code-reviews/)
 - [How to conduct effective code reviews](https://blog.digitalocean.com/how-to-conduct-effective-code-reviews/)
 - [The Art of Code Review](https://skillsmatter.com/skillscasts/8085-the-art-of-code-review) (video, 23 minutes)

--- a/source/resources/other/code-reviews.html.md
+++ b/source/resources/other/code-reviews.html.md
@@ -1,6 +1,6 @@
 ---
-last_reviewed_on: 2018-11-16
-review_in: 1 year
+last_reviewed_on: 2018-12-03
+review_in: 1 month
 title: Code reviews
 ---
 # Code reviews
@@ -46,6 +46,7 @@ reviews.
     _This can help to illustrate the end result of the code, highlight changes
     made or explain your design choices._
 
+If your team is using github, you can set up a [pull request template](https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/) to prompt team members to provide this information whenever they raise a pull request.
 
 ## How to give an effective code review
 
@@ -79,8 +80,10 @@ reviews.
   - Try to respond to every comment.
 
 ## Resources
-http://www.alexandra-hill.com/2018/06/25/the-art-of-giving-and-receiving-code-reviews/
-https://blog.digitalocean.com/how-to-conduct-effective-code-reviews/
-https://dev.to/codemouse92/10-principles-of-a-good-code-review-2eg
-https://github.com/thoughtbot/guides/tree/master/code-review
-https://rubygarage.org/blog/code-review-tips
+- [The art of giving and receiving code reviews](http://www.alexandra-hill.com/2018/06/25/the-art-of-giving-and-receiving-code-reviews/)
+- [How to conduct effective code reviews](https://blog.digitalocean.com/how-to-conduct-effective-code-reviews/)
+- [Mozilla Science Lab: Reviewing a contribution](https://mozillascience.github.io/codeReview/review.html)
+- [Thoughtbot code review guide](https://github.com/thoughtbot/guides/tree/master/code-review)
+- [rOpenSci onboarding guide for reviewers](https://ropensci.github.io/dev_guide/onboarding-guide-for-reviewers.html)
+- [10 principles of a good code review](https://dev.to/codemouse92/10-principles-of-a-good-code-review-2eg)
+- [Code review tips](https://rubygarage.org/blog/code-review-tips)

--- a/source/ways-of-learning/index.html.md.erb
+++ b/source/ways-of-learning/index.html.md.erb
@@ -48,7 +48,7 @@ Many skills are best developed through working on a project as part of a team.
 This can include:
 
 - building and supporting software
-- participating in code reviews
+- participating in [code reviews](/resources/other/code-reviews.html)
 - attending incident reviews
 - participating in show & tells
 - writing and speaking about your work externally


### PR DESCRIPTION
This adds some links to the code review guide, links other guides to this one, and moves some content from other places into it.

I've also directly incorporated the links from https://github.com/alphagov/styleguides/blob/master/pull-requests.md as I think this page should be the most complete list of resources about how to review code and raise PRs, whereas the GDS way/styleguides is specifically *how we do things at GDS*.