### PR TITLE
Set the host

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -1,5 +1,5 @@
 # Host to use for canonical URL generation (without trailing slash)
-host:
+host: https://gds-tech-learning-pathway.cloudapps.digital
 
 # Header-related options
 show_govuk_logo: true


### PR DESCRIPTION
At the moment some of the URLs are being generates as relative paths.
This breaks the tech-docs-monitor bot.