### PR TITLE
Review pair programming and sharing knowledge

### DIFF
--- a/source/career-path/leading-and-communicating/pair-programming.html.md
+++ b/source/career-path/leading-and-communicating/pair-programming.html.md
@@ -1,6 +1,6 @@
 ---
 weight: 60
-last_reviewed_on: 2018-12-27
+last_reviewed_on: 2019-01-17
 review_in: 3 months
 title: Pair programming
 ---

--- a/source/career-path/leading-and-communicating/sharing-knowledge-with-others.html.md
+++ b/source/career-path/leading-and-communicating/sharing-knowledge-with-others.html.md
@@ -1,6 +1,6 @@
 ---
 weight: 40
-last_reviewed_on: 2018-11-16
+last_reviewed_on: 2019-01-17
 review_in: 1 month
 title: Sharing knowledge with others
 ---
@@ -32,13 +32,14 @@ Some ways you can share knowledge externally:
 As a developer or webops at GDS you will [code in the open](https://gds-way.cloudapps.digital/standards/source-code.html#source-code), so you should understand how to handle sensitive information (like passwords) independently of the application source code.
 
 ### Junior level
+
 You can demonstrate work at Show and Tell events and within your team.
 
 You can also volunteer for the monthly Technospective to give a longer talk on a specific topic.
 
 ### Mid level
 
-[Working together with other developers](/career-path/competencies/leading-and-communicating/pair-programming.html) is a really good way to share knowledge, since you get to see other dev's workflow, environment and editor/ide config, and general approaches to problem solving.
+[Working together with other developers](/career-path/competencies/leading-and-communicating/pair-programming.html) is a really good way to share knowledge, since you get to see other developer's workflow, environment and editor/IDE config, and general approaches to problem solving.
 
 You should also regularly review other developers' pull requests. It's a good idea to check other work-in-progress before picking up new stories, so that code review doesn't become a bottleneck for the team. See the [How to review code](https://gds-way.cloudapps.digital/manuals/code-review-guidelines.html) on the GDS way website for guidance about how to do code reviews well.
 


### PR DESCRIPTION
Update the date on the pair programming notes.

Some minor tweaks on the knowledge sharing - whitespace for consistency, uppercase IDE and change "dev" to "developer"